### PR TITLE
treat exception in check_format as can't convert

### DIFF
--- a/cravat/cravat_convert.py
+++ b/cravat/cravat_convert.py
@@ -288,7 +288,10 @@ class MasterCravatConverter(object):
                 first_file = self.first_input_file()
                 first_file.seek(0)
                 for converter_name, converter in self.converters.items():
-                    check_success = converter.check_format(first_file)
+                    try:
+                        check_success = converter.check_format(first_file)
+                    except:
+                        check_success = False
                     first_file.seek(0)
                     if check_success:
                         valid_formats.append(converter_name)


### PR DESCRIPTION
If a converter has an exception in `check_format` for a particular input file, it will now be marked as unable to convert that file. Previously, this error would halt execution.